### PR TITLE
Remove duplicate info/error text

### DIFF
--- a/app.js
+++ b/app.js
@@ -74,13 +74,6 @@ let App = create({
               WARN: Self-signed cert found for {ip}, this will need to be replaced in the future <a href="https://github.com/matrix-org/matrix-doc/pull/1711">MSC1711</a>
             </div>)
           }
-
-          recursiveCheck(report.Checks, "Checks", (path) => {
-            // Found an error
-            tldr.push(<div className="error" key={`${path}-${tldr.length}`}>
-              ERROR: on {ip}: {path} failed
-            </div>)
-          })
         })
         this.setState({
           json: json,

--- a/app.js
+++ b/app.js
@@ -75,15 +75,6 @@ let App = create({
             </div>)
           }
 
-          Object.keys(report.Info).forEach((infoKey) => {
-            let bool = report.Info[infoKey]
-            if (!bool) {
-              tldr.push(<div className="info" key={`cert-${tldr.length}`}>
-                INFO: No {infoKey} for {ip}
-              </div>)
-            }
-          })
-
           recursiveCheck(report.Checks, "Checks", (path) => {
             // Found an error
             tldr.push(<div className="error" key={`${path}-${tldr.length}`}>


### PR DESCRIPTION
We already have a visual block for information/errors, and as #1 suggests the current wording on the INFO display at the top can be confusing. This PR removes the duplicate information.

We should however be displaying more detailed information somewhere, but the current code does not do this.

Closes #1