### PR TITLE
Use the new location of the ValidCertificates check in the response schema

### DIFF
--- a/app.js
+++ b/app.js
@@ -72,7 +72,8 @@ let App = create({
           if (!report.Checks.ValidCertificates) {
             tldr.push(<div className="warning" key={`cert-${tldr.length}`}>
               WARN: Could not find a valid certificate for {ip}.
-              See <a href="https://github.com/matrix-org/synapse/blob/master/docs/MSC1711_certificates_FAQ.md#configuring-certificates-for-compatibility-with-synapse-100">this documentation</a> for instructions on how to fix this.
+              See <a href="https://github.com/matrix-org/synapse/blob/master/docs/MSC1711_certificates_FAQ.md#configuring-certificates-for-compatibility-with-synapse-100">this
+              documentation</a> for instructions on how to fix this.
             </div>)
           }
         })
@@ -264,10 +265,6 @@ let ReportTable = create({
         <h3>{this.props.ip}</h3>
         <div className="table">
           <div className="body">
-            <div className="row">
-              <div className="col">Valid Certificate</div>
-              <div className={"col bool " + rows.cert.className}>{rows.cert.symbol}</div>
-            </div>
             <div className="row toggle" onClick={() => this.toggle("info")}>
               {infoIcon}
               <div className="col">Information</div>

--- a/app.js
+++ b/app.js
@@ -71,7 +71,7 @@ let App = create({
           let report = json.ConnectionReports[ip]
           if (!report.Checks.ValidCertificates) {
             tldr.push(<div className="warning" key={`cert-${tldr.length}`}>
-              WARN: Self-signed cert found for {ip}, this will need to be replaced in the future <a href="https://github.com/matrix-org/matrix-doc/pull/1711">MSC1711</a>
+              WARN: Couldn't find a valid certificate for {ip}, this will need to be fixed in the future as per <a href="https://github.com/matrix-org/matrix-doc/pull/1711">MSC1711</a>
             </div>)
           }
         })

--- a/app.js
+++ b/app.js
@@ -71,7 +71,8 @@ let App = create({
           let report = json.ConnectionReports[ip]
           if (!report.Checks.ValidCertificates) {
             tldr.push(<div className="warning" key={`cert-${tldr.length}`}>
-              WARN: Could not find a valid certificate for {ip}. This will cause federation to stop working as soon as <a href="https://github.com/matrix-org/matrix-doc/pull/1711">MSC1711</a> starts being enforced and must be fixed soon. See <a href="https://github.com/matrix-org/synapse/blob/master/docs/MSC1711_certificates_FAQ.md#configuring-certificates-for-compatibility-with-synapse-100">this documentation</a> for instructions on how to fix it.
+              WARN: Could not find a valid certificate for {ip}.
+              See <a href="https://github.com/matrix-org/synapse/blob/master/docs/MSC1711_certificates_FAQ.md#configuring-certificates-for-compatibility-with-synapse-100">this documentation</a> for instructions on how to fix this.
             </div>)
           }
         })

--- a/app.js
+++ b/app.js
@@ -71,7 +71,7 @@ let App = create({
           let report = json.ConnectionReports[ip]
           if (!report.Checks.ValidCertificates) {
             tldr.push(<div className="warning" key={`cert-${tldr.length}`}>
-              WARN: Could not find a valid certificate for {ip}. This will cause federation to stop working as soon as <a href="https://github.com/matrix-org/matrix-doc/pull/1711">MSC1711</a> starts being enforced and must be fixed soon. If you're running Synapse, see [this documentation](https://github.com/matrix-org/synapse/blob/master/docs/MSC1711_certificates_FAQ.md#configuring-certificates-for-compatibility-with-synapse-100) for instructions on how to fix it.
+              WARN: Could not find a valid certificate for {ip}. This will cause federation to stop working as soon as <a href="https://github.com/matrix-org/matrix-doc/pull/1711">MSC1711</a> starts being enforced and must be fixed soon. See <a href="https://github.com/matrix-org/synapse/blob/master/docs/MSC1711_certificates_FAQ.md#configuring-certificates-for-compatibility-with-synapse-100">this documentation</a> for instructions on how to fix it.
             </div>)
           }
         })

--- a/app.js
+++ b/app.js
@@ -71,7 +71,7 @@ let App = create({
           let report = json.ConnectionReports[ip]
           if (!report.Checks.ValidCertificates) {
             tldr.push(<div className="warning" key={`cert-${tldr.length}`}>
-              WARN: Couldn't find a valid certificate for {ip}, this will need to be fixed in the future as per <a href="https://github.com/matrix-org/matrix-doc/pull/1711">MSC1711</a>
+              WARN: Could not find a valid certificate for {ip}. This will cause federation to stop working as soon as <a href="https://github.com/matrix-org/matrix-doc/pull/1711">MSC1711</a> starts being enforced and must be fixed soon. If you're running Synapse, see [this documentation](https://github.com/matrix-org/synapse/blob/master/docs/MSC1711_certificates_FAQ.md#configuring-certificates-for-compatibility-with-synapse-100) for instructions on how to fix it.
             </div>)
           }
         })

--- a/app.js
+++ b/app.js
@@ -69,7 +69,7 @@ let App = create({
         let tldr = []
         Object.keys(json.ConnectionReports).forEach((ip) => {
           let report = json.ConnectionReports[ip]
-          if (!report.ValidCertificates) {
+          if (!report.Checks.ValidCertificates) {
             tldr.push(<div className="warning" key={`cert-${tldr.length}`}>
               WARN: Self-signed cert found for {ip}, this will need to be replaced in the future <a href="https://github.com/matrix-org/matrix-doc/pull/1711">MSC1711</a>
             </div>)
@@ -254,7 +254,7 @@ let ReportTable = create({
       rows.checks = trueRow
     }
 
-    if (this.props.info.ValidCertificates) {
+    if (this.props.info.Checks.ValidCertificates) {
       rows.cert = trueRow
     }
 


### PR DESCRIPTION
Caused by https://github.com/matrix-org/matrix-federation-tester/pull/75

Also fixes #3 