### PR TITLE
Display errors from the federation tester's connection reports

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,6 +76,13 @@ let App = create({
               documentation</a> for instructions on how to fix this.
             </div>)
           }
+          json.ConnectionReports[ip].Errors.forEach((err) => {
+              let msg = err.Message
+              // Found an error
+              tldr.push(<div className="error" key={`${msg}-${tldr.length}`}>
+                ERROR: on {ip}: {msg}
+              </div>)
+          })
         })
         this.setState({
           json: json,


### PR DESCRIPTION
Here's how it renders with, e.g., a self-signed certificate:

![image](https://user-images.githubusercontent.com/5547783/55102790-1999db80-50bf-11e9-9d04-8bdf9492e487.png)
