### PR TITLE
Provide a nicer display when there's no connection report

### DIFF
--- a/app.js
+++ b/app.js
@@ -404,20 +404,58 @@ let DNSResult = create({
           <div className="col">{record.Target}</div>
           <div className="col">{record.Port}</div>
           <div className="col">{record.Priority}</div>
-          <div className="col">{record.Target}</div>
+          <div className="col">{record.Weight}</div>
         </div>
       );
     });
 
     let hosts = Object.keys(j.Hosts).map((host) => {
-      return j.Hosts[host].Addrs.map((address, id) => {
-        return (
-          <div className="row" key={id}>
-            <div className="col">{address}</div>
-          </div>
-        );
-      });
+      if (j.Hosts[host].Addrs != null) {
+        return j.Hosts[host].Addrs.map((address, id) => {
+          return (
+            <div className="row" key={id}>
+              <div className="col">{address}</div>
+            </div>
+          );
+        });
+      }
     });
+    hosts = hosts.filter((host) => host != undefined)
+
+    let hostErrors = Object.keys(j.Hosts).map((host) => {
+      if (j.Hosts[host].Error != null) {
+        return (
+          <div className="row" key={host}>
+            <div className="col">{j.Hosts[host].Error.Message}</div>
+          </div>
+        )
+      }
+    });
+    hostErrors = hostErrors.filter((error) => error != undefined)
+
+    let addresses;
+    if (hosts.length > 0) {
+      addresses = <>
+        <div className="head">
+          Addresses
+        </div>
+        <div className="body">
+          {hosts}
+        </div>
+      </>
+    }
+
+    let errors;
+    if (hostErrors.length > 0) {
+      errors = <>
+        <div className="head error">
+          Errors
+        </div>
+        <div className="body error">
+          {hostErrors}
+        </div>
+      </>
+    }
 
     return (
       <div className="dns">
@@ -427,19 +465,15 @@ let DNSResult = create({
             <span className="col">Target</span>
             <span className="col">Port</span>
             <span className="col">Priority</span>
-            <span className="col">Target</span>
+            <span className="col">Weight</span>
           </div>
           <div className="body">
             {records}
           </div>
         </div>
         <div className="table">
-          <div className="head">
-            Address
-          </div>
-          <div className="body">
-            {hosts}
-          </div>
+          {addresses}
+          {errors}
         </div>
       </div>
     );

--- a/app.js
+++ b/app.js
@@ -103,22 +103,15 @@ let App = create({
 
     if (this.state.json != undefined) {
       let reportCount = Object.keys(this.state.json.ConnectionReports).length
-      if (reportCount == 0) {
-        errors = (
-          <div className="error">
-            No connection reports, is this even a matrix server?
-          </div>
-        )
-      } else {
-        result = <>
-          Got {reportCount} connection report{reportCount > 1 && <>s</>}
+      result = <>
+        Got {reportCount} connection report{reportCount > 1 && <>s</>}.
+        {reportCount == 0 && <> This usually means at least one error happened.</>}
 
-          <div className="tldr">
-            {this.state.tldr}
-          </div>
-          <TestResults json={this.state.json}/>
-        </>
-      }
+        <div className="tldr">
+          {this.state.tldr}
+        </div>
+        <TestResults json={this.state.json}/>
+      </>
     }
 
     return (
@@ -170,6 +163,9 @@ let ConnectionReports = create({
 
   render: function() {
     let j = this.props.json;
+    if (Object.keys(j).length == 0) {
+      return null;
+    }
     let connections = Object.keys(j).map((ip, id) => {
       let info = j[ip];
       return <ReportTable info={info} key={id} ip={ip}/>;

--- a/public/scss/style.scss
+++ b/public/scss/style.scss
@@ -263,3 +263,11 @@ input {
     }
   }
 }
+
+.dns .error {
+  color: $red;
+}
+
+.dns .body.error {
+  color: lighten($red, 20);
+}


### PR DESCRIPTION
When there's no connection report, don't display nothing but a ambiguous message, instead explain that this probably happened because of an error and actually display the errors that happened in the process.

Also changed the way DNS lookup results are processed so we can display lookup errors.

Final result looks like this:

![image](https://user-images.githubusercontent.com/5547783/55487562-3f2a6600-5626-11e9-9cb8-79cbcb4a13bc.png)
