### PR TITLE
Prevent non-dropdown items from being clickable

### DIFF
--- a/app.js
+++ b/app.js
@@ -352,7 +352,7 @@ let TableFromObject = create({
           }
           return (
             <div key={id}>
-              <div className={"row toggle tree-" + this.props.tree} onClick={this.toggle}>
+              <div className={"row tree-" + this.props.tree} onClick={this.toggle}>
                 <div className="col">{check}</div>
                 <div className={"col bool " + childrenBool}>{childrenSymbol}</div>
               </div>

--- a/app.js
+++ b/app.js
@@ -337,7 +337,7 @@ let TableFromObject = create({
       } else if (!this.props.collapsed) {
         if (typeof(this.props.object[check]) == "boolean") {
           return (
-            <div className={`row toggle tree-${this.props.tree} ${this.props.type}Row`} key={id}>
+            <div className={`row tree-${this.props.tree} ${this.props.type}Row`} key={id}>
               <div className="col">{check}</div>
               <div className={"col bool " + className}>{symbol}</div>
             </div>


### PR DESCRIPTION
Stops the "click" cursor from appearing over block items that aren't collapsible.