### PR TITLE
Add a message when MatchingServerName failed

### DIFF
--- a/app.js
+++ b/app.js
@@ -83,6 +83,17 @@ let App = create({
                 ERROR: on {ip}: {msg}
               </div>)
           })
+          if (!report.Checks.MatchingServerName) {
+            tldr.push(
+              <div className="warning" key={`servername-${tldr.length}`}>
+              It is possible that the MatchingServerName error below is
+              caused by you entering the wrong URL in the federation tester,
+              not an actual issue with your federation. You should enter the
+              server name into the Federation Tester, not the location
+              where your server is.
+              </div>
+            )
+          }
         })
         this.setState({
           json: json,

--- a/app.js
+++ b/app.js
@@ -83,9 +83,6 @@ let App = create({
                 ERROR: on {ip}: {msg}
               </div>)
           })
-          if (!report.Checks.MatchingServerName) {
-            
-          }
         })
         if (Object.values(json.ConnectionReports).some(e=>!e.Checks.MatchingServerName)) {
           tldr.push(

--- a/app.js
+++ b/app.js
@@ -84,17 +84,22 @@ let App = create({
               </div>)
           })
           if (!report.Checks.MatchingServerName) {
-            tldr.push(
+            
+          }
+        })
+        if (Object.values(json.ConnectionReports).some(e=>!e.Checks.MatchingServerName)) {
+          tldr.push(
               <div className="warning" key={`servername-${tldr.length}`}>
               It is possible that the MatchingServerName error below is
               caused by you entering the wrong URL in the federation tester,
-              not an actual issue with your federation. You should enter the
-              server name into the Federation Tester, not the location
-              where your server is.
+              not because there is an actual issue with your federation.
+              You should enter the server name into the Federation Tester,
+              not the location where your server is. The server name is the
+              public facing name of your server that appears at the end of
+              usernames and room aliases.
               </div>
             )
-          }
-        })
+        }
         this.setState({
           json: json,
           tldr: tldr,


### PR DESCRIPTION
Wording probably could be improved, ~~also it would be nice not to show this for both IPs.~~

Fixes https://github.com/matrix-org/matrix-federation-tester/issues/87 (which should have been in this repo, feel free to transfer)