### PR TITLE
Add message that SRV check was skipped if .well-known is configured

### DIFF
--- a/app.js
+++ b/app.js
@@ -408,7 +408,7 @@ let DNSResult = create({
     if (j.SRVSkipped) {
       return (
         <div className="dns">
-          <h2>.well-known information found -&gt; SRV record-check skipped</h2>
+          <h2>server name/.well-known result contains explicit port number: no SRV lookup done</h2>
         </div>
       );
     }

--- a/app.js
+++ b/app.js
@@ -405,45 +405,64 @@ let DNSResult = create({
   render: function() {
     let j = this.props.json;
 
+    let dnsResultTitle = <> <h3>DNS records for {j.SRVCName}</h3> </>
     if (j.SRVSkipped) {
-      return (
-        <div className="dns">
-          <h2>server name/.well-known result contains explicit port number: no SRV lookup done</h2>
-        </div>
-      );
+        dnsResultTitle = <>
+          <h3>DNS records</h3>
+          <p>server name/.well-known result contains explicit port number: no SRV lookup done</p>
+        </>;
     }
 
-    if (j.SRVRecords == null) {
-      return (
-        <div className="dns">
-          <h2>No SRV Records</h2>
-        </div>
-      );
+    let records;
+    if (j.SRVRecords != null) {
+      const recordRows = j.SRVRecords.map((record, id) => {
+        return (
+          <div className="row" key={id}>
+            <div className="col">{record.Target}</div>
+            <div className="col">{record.Port}</div>
+            <div className="col">{record.Priority}</div>
+            <div className="col">{record.Weight}</div>
+          </div>
+        );
+      });
+      records = <>
+          <div className="header">
+            <span className="col">Target</span>
+            <span className="col">Port</span>
+            <span className="col">Priority</span>
+            <span className="col">Weight</span>
+          </div>
+          <div className="body">
+            {recordRows}
+          </div>
+        </>;
     }
-
-    let records = j.SRVRecords.map((record, id) => {
-      return (
-        <div className="row" key={id}>
-          <div className="col">{record.Target}</div>
-          <div className="col">{record.Port}</div>
-          <div className="col">{record.Priority}</div>
-          <div className="col">{record.Weight}</div>
-        </div>
-      );
-    });
 
     let hosts = Object.keys(j.Hosts).map((host) => {
       if (j.Hosts[host].Addrs != null) {
-        return j.Hosts[host].Addrs.map((address, id) => {
+        const addresses = j.Hosts[host].Addrs.map((address, id) => {
           return (
             <div className="row" key={id}>
               <div className="col">{address}</div>
             </div>
           );
         });
+
+        return (
+          <>
+            <h3>{host}</h3>
+            <div className="head">
+                Addresses
+            </div>
+            <div className="body">
+              {addresses}
+            </div>
+          </>
+        );
       }
     });
-    hosts = hosts.filter((host) => host != undefined)
+
+    hosts = hosts.filter((host) => host != undefined);
 
     let hostErrors = Object.keys(j.Hosts).map((host) => {
       if (j.Hosts[host].Error != null) {
@@ -451,22 +470,10 @@ let DNSResult = create({
           <div className="row" key={host}>
             <div className="col">{j.Hosts[host].Error.Message}</div>
           </div>
-        )
+        );
       }
     });
-    hostErrors = hostErrors.filter((error) => error != undefined)
-
-    let addresses;
-    if (hosts.length > 0) {
-      addresses = <>
-        <div className="head">
-          Addresses
-        </div>
-        <div className="body">
-          {hosts}
-        </div>
-      </>
-    }
+    hostErrors = hostErrors.filter((error) => error != undefined);
 
     let errors;
     if (hostErrors.length > 0) {
@@ -477,25 +484,19 @@ let DNSResult = create({
         <div className="body error">
           {hostErrors}
         </div>
-      </>
+      </>;
     }
 
     return (
       <div className="dns">
-        <h2>DNS records for {j.SRVCName}</h2>
+        <h2>DNS results</h2>
+        {dnsResultTitle}
         <div className="table">
-          <div className="header">
-            <span className="col">Target</span>
-            <span className="col">Port</span>
-            <span className="col">Priority</span>
-            <span className="col">Weight</span>
-          </div>
-          <div className="body">
-            {records}
-          </div>
+          {records}
         </div>
         <div className="table">
-          {addresses}
+          <h3>Hosts</h3>
+          {hosts}
           {errors}
         </div>
       </div>

--- a/app.js
+++ b/app.js
@@ -404,6 +404,15 @@ let DNSResult = create({
 
   render: function() {
     let j = this.props.json;
+
+    if (j.SRVSkipped) {
+      return (
+        <div className="dns">
+          <h2>.well-known information found -&gt; SRV record-check skipped</h2>
+        </div>
+      );
+    }
+
     if (j.SRVRecords == null) {
       return (
         <div className="dns">

--- a/app.js
+++ b/app.js
@@ -405,12 +405,12 @@ let DNSResult = create({
   render: function() {
     const j = this.props.json;
 
-    const skippedSrvResultTitle = <p>server name/.well-known result contains explicit port number: no SRV lookup done</p>;
-    const foundSrvResultTitle = <h3>DNS records for {j.SRVCName}</h3>;
-    const srvResultTitle = j.SRVSkipped ? skippedSrvResultTitle : foundSrvResultTitle;
-
     const srvRecordsTable = function() {
-      if (j.SRVRecords != null) {
+      if (j.SRVSkipped) {
+        return <p>server name/.well-known result contains explicit port number: no SRV lookup done</p>;
+      } else if (j.SRVRecords == null) {
+        return <p>No SRV records found</p>;
+      } else {
         const recordRows = j.SRVRecords.map((record, id) => {
           return (
             <div className="row" key={id}>
@@ -424,6 +424,7 @@ let DNSResult = create({
 
         return (
           <>
+            <h3>DNS records for {j.SRVCName}</h3>
             <div className="table">
               <div className="header">
                 <span className="col">Target</span>
@@ -495,7 +496,6 @@ let DNSResult = create({
     return (
       <div className="dns">
         <h2>DNS results</h2>
-        {srvResultTitle}
         {srvRecordsTable}
         <h3>Hosts</h3>
         {hosts}

--- a/app.js
+++ b/app.js
@@ -403,101 +403,117 @@ let DNSResult = create({
   displayName: "DNS",
 
   render: function() {
-    let j = this.props.json;
+    const j = this.props.json;
 
-    let dnsResultTitle = <> <h3>DNS records for {j.SRVCName}</h3> </>
-    if (j.SRVSkipped) {
-        dnsResultTitle = <>
-          <h3>DNS records</h3>
-          <p>server name/.well-known result contains explicit port number: no SRV lookup done</p>
-        </>;
-    }
+    const skippedDnsResultTitle = <p>server name/.well-known result contains explicit port number: no SRV lookup done</p>;
+    const foundDnsResultTitle = <h3>DNS records for {j.SRVCName}</h3>;
+    const dnsResultTitle = j.SRVSkipped ? skippedDnsResultTitle : foundDnsResultTitle;
 
-    let records;
-    if (j.SRVRecords != null) {
-      const recordRows = j.SRVRecords.map((record, id) => {
-        return (
-          <div className="row" key={id}>
-            <div className="col">{record.Target}</div>
-            <div className="col">{record.Port}</div>
-            <div className="col">{record.Priority}</div>
-            <div className="col">{record.Weight}</div>
-          </div>
-        );
-      });
-      records = <>
-          <div className="header">
-            <span className="col">Target</span>
-            <span className="col">Port</span>
-            <span className="col">Priority</span>
-            <span className="col">Weight</span>
-          </div>
-          <div className="body">
-            {recordRows}
-          </div>
-        </>;
-    }
-
-    let hosts = Object.keys(j.Hosts).map((host) => {
-      if (j.Hosts[host].Addrs != null) {
-        const addresses = j.Hosts[host].Addrs.map((address, id) => {
+    const srvRecordsTable = function() {
+      if (j.SRVRecords != null) {
+        const recordRows = j.SRVRecords.map((record, id) => {
           return (
             <div className="row" key={id}>
-              <div className="col">{address}</div>
+              <div className="col">{record.Target}</div>
+              <div className="col">{record.Port}</div>
+              <div className="col">{record.Priority}</div>
+              <div className="col">{record.Weight}</div>
             </div>
           );
         });
 
         return (
           <>
-            <h3>{host}</h3>
+            <div className="table">
+              <div className="header">
+                <span className="col">Target</span>
+                <span className="col">Port</span>
+                <span className="col">Priority</span>
+                <span className="col">Weight</span>
+              </div>
+              <div className="body">
+                {recordRows}
+              </div>
+            </div>
+          </>
+        );
+      }
+    }();
+
+    const hosts = Object.keys(j.Hosts).map((host) => {
+      const addresses = function() {
+        if (j.Hosts[host].Addrs != null) {
+          return j.Hosts[host].Addrs.map((address, id) => {
+            return (
+              <div className="row" key={id}>
+                <div className="col">{address}</div>
+              </div>
+            );
+          })
+        }
+      }();
+
+      const errors = function() {
+        if (j.Hosts[host].Error != null) {
+          return (
+            <div className="row" key={host}>
+              <div className="col">{j.Hosts[host].Error.Message}</div>
+            </div>
+          );
+        }
+      }();
+
+      const header = <h4>{host}</h4>;
+      const addressTable = <>
             <div className="head">
                 Addresses
             </div>
             <div className="body">
               {addresses}
             </div>
+          </>;
+      const errorTable = <>
+          <div className="head error">
+            Errors
+          </div>
+          <div className="body error">
+            {errors}
+          </div>
+        </>;
+
+      // Prevent having an empty table with only the header of the address or errors table.
+      if (addresses == undefined) {
+        return (
+          <>
+            {header}
+            {errorTable}
+          </>
+        );
+      } else if (errors == undefined) {
+        return (
+          <>
+            {header}
+            {addressTable}
           </>
         );
       }
+      return (
+        <>
+          {header}
+          {addressTable}
+          {errorTable}
+        </>
+      );
     });
-
-    hosts = hosts.filter((host) => host != undefined);
-
-    let hostErrors = Object.keys(j.Hosts).map((host) => {
-      if (j.Hosts[host].Error != null) {
-        return (
-          <div className="row" key={host}>
-            <div className="col">{j.Hosts[host].Error.Message}</div>
-          </div>
-        );
-      }
-    });
-    hostErrors = hostErrors.filter((error) => error != undefined);
-
-    let errors;
-    if (hostErrors.length > 0) {
-      errors = <>
-        <div className="head error">
-          Errors
-        </div>
-        <div className="body error">
-          {hostErrors}
-        </div>
-      </>;
-    }
 
     return (
       <div className="dns">
         <h2>DNS results</h2>
         {dnsResultTitle}
-        <div className="table">
-          {records}
-        </div>
+        {srvRecordsTable}
         <div className="table">
           <h3>Hosts</h3>
           {hosts}
-          {errors}
         </div>
       </div>
     );

--- a/app.js
+++ b/app.js
@@ -405,9 +405,9 @@ let DNSResult = create({
   render: function() {
     const j = this.props.json;
 
-    const skippedDnsResultTitle = <p>server name/.well-known result contains explicit port number: no SRV lookup done</p>;
-    const foundDnsResultTitle = <h3>DNS records for {j.SRVCName}</h3>;
-    const dnsResultTitle = j.SRVSkipped ? skippedDnsResultTitle : foundDnsResultTitle;
+    const skippedSrvResultTitle = <p>server name/.well-known result contains explicit port number: no SRV lookup done</p>;
+    const foundSrvResultTitle = <h3>DNS records for {j.SRVCName}</h3>;
+    const srvResultTitle = j.SRVSkipped ? skippedSrvResultTitle : foundSrvResultTitle;
 
     const srvRecordsTable = function() {
       if (j.SRVRecords != null) {
@@ -509,7 +509,7 @@ let DNSResult = create({
     return (
       <div className="dns">
         <h2>DNS results</h2>
-        {dnsResultTitle}
+        {srvResultTitle}
         {srvRecordsTable}
         <div className="table">
           <h3>Hosts</h3>

--- a/app.js
+++ b/app.js
@@ -441,67 +441,53 @@ let DNSResult = create({
     }();
 
     const hosts = Object.keys(j.Hosts).map((host) => {
-      const addresses = function() {
-        if (j.Hosts[host].Addrs != null) {
-          return j.Hosts[host].Addrs.map((address, id) => {
-            return (
-              <div className="row" key={id}>
-                <div className="col">{address}</div>
-              </div>
-            );
-          })
-        }
-      }();
+      const addressTable = function() {
+        const addresses = function() {
+          if (j.Hosts[host].Addrs != null) {
+            return j.Hosts[host].Addrs.map((address, id) => {
+              return (
+                <div className="row" key={id}>
+                  <div className="col">{address}</div>
+                </div>
+              );
+            });
+          }
+        }();
 
-      const errors = function() {
-        if (j.Hosts[host].Error != null) {
-          return (
-            <div className="row" key={host}>
-              <div className="col">{j.Hosts[host].Error.Message}</div>
-            </div>
-          );
-        }
-      }();
-
-      const header = <h4>{host}</h4>;
-      const addressTable = <>
+        return (<>
             <div className="head">
                 Addresses
             </div>
             <div className="body">
               {addresses}
             </div>
-          </>;
-      const errorTable = <>
-          <div className="head error">
-            Errors
-          </div>
-          <div className="body error">
-            {errors}
-          </div>
-        </>;
+          </>);
+      }();
 
-      // Prevent having an empty table with only the header of the address or errors table.
-      if (addresses == undefined) {
-        return (
-          <>
-            {header}
-            {errorTable}
-          </>
-        );
-      } else if (errors == undefined) {
-        return (
-          <>
-            {header}
-            {addressTable}
-          </>
-        );
-      }
+      const errorTable = function() {
+        if (j.Hosts[host].Error != null) {
+          return (<>
+            <div className="head error">
+              Errors
+            </div>
+            <div className="body error">
+              <div className="row" key={host}>
+                <div className="col">{j.Hosts[host].Error.Message}</div>
+              </div>
+            </div>
+          </>);
+        }
+      }();
+
       return (
         <>
-          {header}
-          {addressTable}
-          {errorTable}
+          <h4>{host}</h4>
+          <div className="table">
+           {addressTable}
+          </div>
+          <div className="table">
+            {errorTable}
+          </div>
         </>
       );
     });
@@ -511,10 +497,8 @@ let DNSResult = create({
         <h2>DNS results</h2>
         {srvResultTitle}
         {srvRecordsTable}
-        <div className="table">
-          <h3>Hosts</h3>
-          {hosts}
-        </div>
+        <h3>Hosts</h3>
+        {hosts}
       </div>
     );
   }


### PR DESCRIPTION
The backend does not check for the SRV records if a .well-known
configuration with a port declaration was found. It will return an
empty SRVRecords field which leads to the understanding that nothing
was found even though it was intentionally skipped. The newly introduced
message will inform the user that it was skipped because a .well-known
configuration was found.

Tries to resolve #25 

Refs:
- https://github.com/matrix-org/matrix-federation-tester/issues/104