### PR TITLE
Add _headers file for pages

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,6 +83,7 @@ gulp.task('js', function() {
     .pipe(gulp.dest('build'))
 })
 
+// Adds cloudflare pages files to the build dir
 gulp.task("cf", function() {
   return gulp.src(["public/_headers"])
     .pipe(gulp.dest('build'))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,7 +83,7 @@ gulp.task('js', function() {
     .pipe(gulp.dest('build'))
 })
 
-// Adds cloudflare pages files to the build dir
+// Adds files for Cloudflare Pages to the build dir
 gulp.task("cf", function() {
   return gulp.src(["public/_headers"])
     .pipe(gulp.dest('build'))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,6 +83,11 @@ gulp.task('js', function() {
     .pipe(gulp.dest('build'))
 })
 
-gulp.task('build', gulp.parallel(['clean', 'assets', 'js', 'sass', function(done) {
+gulp.task("cf", function() {
+  return gulp.src(["public/_headers"])
+    .pipe(gulp.dest('build'))
+})
+
+gulp.task('build', gulp.parallel(['clean', 'assets', 'js', 'sass', 'cf', function(done) {
   done()
 }]))

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,2 @@
+/*
+  ! Access-Control-Allow-Origin

--- a/public/_headers
+++ b/public/_headers
@@ -1,3 +1,3 @@
-# Remove the ACAO header which is added by default on cloudflare pages
+# Remove the ACAO header which is added by default on Cloudflare Pages
 /*
   ! Access-Control-Allow-Origin

--- a/public/_headers
+++ b/public/_headers
@@ -1,2 +1,3 @@
+# Remove the ACAO header which is added by default on cloudflare pages
 /*
   ! Access-Control-Allow-Origin


### PR DESCRIPTION
Disable the default behaviour of `adding access-control-allow-origin: *` to pages sites
