### PR TITLE
Add warning when exclusively deprecated SRV records are in use

### DIFF
--- a/app.js
+++ b/app.js
@@ -99,6 +99,12 @@ let App = create({
               </div>
             )
         }
+        if (typeof json.DNSResult.SRVCName === "string" && !json.DNSResult.SRVCName.startsWith("_matrix-fed.")) {
+          tldr.push(<div className="warning" key={`srv-deprecated-${tldr.length}`}>
+            WARN: Deprecated SRV record <code>_matrix</code> in use. Please
+            add an additional SRV record to cover <code>_matrix-fed</code> too.
+          </div>)
+        }
         this.setState({
           json: json,
           tldr: tldr,


### PR DESCRIPTION
Paired with https://github.com/matrix-org/matrix-federation-tester/pull/142

Domain tests:

<details>
<summary><code>3c.s.resolvematrix.dev</code> - <code>_matrix</code> only, <code>.well-known</code></summary>

![image](https://github.com/matrix-org/fed-tester-ui/assets/1190097/19cd4080-7bbe-4b5c-a258-dff10cd60b89)

</details>

<details>
<summary><code>4.s.resolvematrix.dev</code> - <code>_matrix</code> only</summary>

![image](https://github.com/matrix-org/fed-tester-ui/assets/1190097/7e93b092-e1ee-4fcf-b37a-9879190a6ff3)

</details>

<details>
<summary><code>3c.msc4040.s.resolvematrix.dev</code> - <code>_matrix-fed</code> only, <code>.well-known</code></summary>

![image](https://github.com/matrix-org/fed-tester-ui/assets/1190097/a13c5ba5-7178-4079-b054-623133d97e64)

</details>

<details>
<summary><code>4.msc4040.s.resolvematrix.dev</code> - <code>_matrix-fed</code> only</summary>

![image](https://github.com/matrix-org/fed-tester-ui/assets/1190097/e4322d01-3a2b-411f-8d1c-28353a2a7655)

</details>

<details>
<summary><code>t2l.io</code> - <code>_matrix-fed</code> and <code>_matrix</code> fallback</summary>

(TODO: Update resolvematrix.dev to support this case)

![image](https://github.com/matrix-org/fed-tester-ui/assets/1190097/b48ba7cb-ce24-41fd-b40e-fa1903ad57cc)

</details>